### PR TITLE
FIXED: Safari slowdowns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2648,6 +2648,11 @@
         "reusify": "^1.0.4"
       }
     },
+    "fflate": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.1.tgz",
+      "integrity": "sha512-VYM2Xy1gSA5MerKzCnmmuV2XljkpKwgJBKezW+495TTnTCh1x5HcYa1aH8wRU/MfTGhW4ziXqgwprgQUVl3Ohw=="
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "webpack-cli": "^4.9.1"
   },
   "dependencies": {
+    "fflate": "^0.7.1",
     "nipplejs": "^0.9.0"
   }
 }


### PR DESCRIPTION
Apparently there was some optimizations that were disabled. This was fixed by replacing `var` variable definitions with `let`: odd...

This PR also replaces `pack` with `fflate` which should be smaller & faster.

Fixes #8 